### PR TITLE
Don't try to require() core Lua libraries from JSON4Lua

### DIFF
--- a/mods/base/req/json.lua
+++ b/mods/base/req/json.lua
@@ -31,9 +31,9 @@
 -----------------------------------------------------------------------------
 -- Imports and dependencies
 -----------------------------------------------------------------------------
-local math = require('math')
-local string = require("string")
-local table = require("table")
+local math = math
+local string = string
+local table = table
 local tostring = tostring
 
 local base = _G


### PR DESCRIPTION
The JSON4Lua code works fine as long as the require() statements are
rewritten to just directly grab the core libraries it needs since
they're already defined and require() within the game will just crash if
it's told to get something that's not a bundled Lua.