### PR TITLE
Convert priority to number incase it is a string

### DIFF
--- a/mods/base/base.lua
+++ b/mods/base/base.lua
@@ -188,7 +188,7 @@ if not _loaded_mod_folders then
 							local data = {
 								path = mod_path,
 								definition = mod_content,
-								priority = mod_content.priority or 0,
+								priority = tonumber(mod_content.priority) or 0,
 							}
 							table.insert( _mods, data )
 						else


### PR DESCRIPTION
If by mistake someone inputs priority: "10" into their mod.txt It will break and cause all mods to fail to load. So we should just convert it to a number to prevent such simple mistakes for the users sake.