### PR TITLE
Disables the 1 minute max on downloads

### DIFF
--- a/src/http/http.cpp
+++ b/src/http/http.cpp
@@ -119,8 +119,6 @@ void launch_thread_http(HTTPItem *raw_item){
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 60);
-
 	if (item->progress){
 		curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, http_progress_call);
 		curl_easy_setopt(curl, CURLOPT_XFERINFODATA, item.get());


### PR DESCRIPTION
Before Beardlib and custom assets were a thing, this made sense. However, nowadays, we're hitting the issue of not being able to push autoupdates for certain mods due to the mods not downloading within 60 seconds.