### PR TITLE
VR Beta support

### DIFF
--- a/src/InitiateState.cpp
+++ b/src/InitiateState.cpp
@@ -90,7 +90,7 @@ namespace pd2hook
 	CREATE_NORMAL_CALLABLE_SIGNATURE(luaL_unref, void, "\x53\x8B\x5C\x24\x10\x85\xDB\x78\x67\x56\x8B\x74\x24\x0C\x57\x8B", "xxxxxxxxxxxxxxxx", 0, lua_State*, int, int);
 	CREATE_CALLABLE_CLASS_SIGNATURE(do_game_update, void*, "\x56\xFF\x74\x24\x0C\x8B\xF1\x68\x00\x00\x00\x00\xFF\x36\xE8", "xxxxxxxx????xxx", 0, int*, int*)
 		CREATE_CALLABLE_CLASS_SIGNATURE(luaL_newstate, int, "\x53\x56\x33\xDB\x57\x8B\xF1\x39\x5C\x24\x18\x0F", "xxxxxxxxxxxx", 0, char, char, int)
-		CREATE_CALLABLE_CLASS_SIGNATURE(luaL_newstate_vr, int, "\x8B\x44\x24\x0C\x56\x8B\xF1\x85\xC0\x75\x08\x50\x68\x70\x86\x7E", "xxxxxxxxxxxxxxxx", 0, char, char, int)
+		CREATE_CALLABLE_CLASS_SIGNATURE(luaL_newstate_vr, int, "\x8B\x44\x24\x0C\x56\x8B\xF1\x85\xC0\x75\x08\x50\x68\xE0\x87\x7E", "xxxxxxxxxxxxxxxx", 0, char, char, int)
 
 		// lua c-functions
 

--- a/src/signatures/signatures.cpp
+++ b/src/signatures/signatures.cpp
@@ -50,10 +50,25 @@ SignatureSearch::SignatureSearch(const char* funcname, void* adress, const char*
 }
 
 void SignatureSearch::Search(){
-	printf("Scanning for signatures.\n");
+	// Find the name of the current EXE
+	TCHAR processPath[MAX_PATH + 1];
+	GetModuleFileName(NULL, processPath, MAX_PATH + 1); // Get the path
+	TCHAR filename[MAX_PATH + 1];
+	_splitpath_s( // Find the filename part of the path
+		processPath, // Input
+		NULL, 0, // Don't care about the drive letter
+		NULL, 0, // Don't care about the directory
+		filename, MAX_PATH, // Grab the filename
+		NULL, 0 // Extension is always .exe
+	);
+
+	// Add the .exe back on
+	strcat_s(filename, MAX_PATH, ".exe");
+
+	printf("Scanning for signatures in %s.\n", filename);
 	std::vector<SignatureF>::iterator it;
 	for (it = allSignatures->begin(); it < allSignatures->end(); it++){
-		*((void**)it->address) = (void*)(FindPattern("payday2_win32_release.exe", it->funcname, it->signature, it->mask) + it->offset);
+		*((void**)it->address) = (void*)(FindPattern(filename, it->funcname, it->signature, it->mask) + it->offset);
 	}
 }
 


### PR DESCRIPTION
This patch adds support for using the VR beta.

As the beta is stored in a seperate EXE, when scanning for signatures the name of the current executable will be used, as opposed to the hardcoded EXE name. This fixes the crash-on-startup, removing the need to delete IPHLPAPI.dll before using VR mode.

luaL_newstate is also changed (although I paid no attention to how it was changed), but only for the VR version. BLT now tries to hook both versions, and if the VR version runs it sets a flag that causes `blt.getvrstate()` to return true, allowing special behavior for mods when in VR.